### PR TITLE
Mark package as abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "altapay/sdk-php",
     "license": "MIT",
+    "abandoned": "altapay/api-php"
     "description": "AltaPay: Payments less complicated",
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
This won't prevent anyone from using it, but will make it clear that to get updates they must migrate to the one that is maintained.

I would also suggest making the the repo Archived and possibility updating the readme to point to https://github.com/AltaPay/api-php as the replacement.